### PR TITLE
[EdgeTPU] Add EdgeTPU Input Path to CfgEditor

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -221,9 +221,27 @@ limitations under the License.
                 </div>
             </div>
             <div class="basic" id="optionImportEdgeTPUBasic">
+                <div class="title">
+                    Basic Options
+                </div>
                 <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
+                <div class="option">
+                    <vscode-text-field id="EdgeTPUInputPath" startIcon="true" size="50" placeholder="">
+                        Input Path
+                        <span id="EdgeTPUInputPathSearch" slot="end" class="codicon codicon-search" style="cursor: pointer"></span>
+                    </vscode-text-field>
+                </div>
+                <div class="option">
+                    <vscode-text-field id="EdgeTPUOutputPath" startIcon="true" size="50" placeholder="" disabled="true">
+                        Output Path
+                        <span id="EdgeTPUOutputPathSearch" slot="end" class="codicon codicon-search" style="cursor: pointer"></span>
+                    </vscode-text-field>
+                </div>
             </div>
             <div class="advanced" id="optionImportEdgeTPUAdvanced">
+                <div class="title">
+                    Compile Options
+                </div>
                 <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
             </div>
         </div>

--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -240,7 +240,7 @@ limitations under the License.
             </div>
             <div class="advanced" id="optionImportEdgeTPUAdvanced">
                 <div class="title">
-                    Compile Options
+                    Advanced Options
                 </div>
                 <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
             </div>

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -142,6 +142,15 @@ export function displayCfgToEditor(cfg) {
 
   // TODO Support one-import-bcq
 
+  // TODO Support import EdgeTPU
+  const oneImportEdgeTPU = cfg["one-import-edgetpu"];
+  document.getElementById("EdgeTPUInputPath").value = cfgString(
+    oneImportEdgeTPU?.["input_path"]
+  );
+  document.getElementById("EdgeTPUOutputPath").value = cfgString(
+    oneImportEdgeTPU?.["output_path"]
+  );
+
   updateImportUI();
 
   const oneOptimize = cfg["one-optimize"];

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -336,7 +336,13 @@ function registerONNXOptions() {
   });
 }
 
-function registerEdgeTPUOptions() {}
+function registerEdgeTPUOptions() {
+  const edgeTPUInputPath = document.getElementById("EdgeTPUInputPath");
+  edgeTPUInputPath.addEventListener("input", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+}
 
 function registerOptimizeOptions() {
   const optimizeInputPath = document.getElementById("optimizeInputPath");
@@ -760,6 +766,18 @@ function registerCodiconEvents() {
         oldPath: document.getElementById("CopyQuantOutputPath").value,
         postStep: "QuantizeCopy",
         postElemID: "CopyQuantOutputPath",
+      });
+    });
+  document
+    .getElementById("EdgeTPUInputPathSearch")
+    .addEventListener("click", function () {
+      postMessageToVsCode({
+        type: "getPathByDialog",
+        isFolder: false,
+        ext: ["tflite"],
+        oldPath: document.getElementById("EdgeTPUInputPath").value,
+        postStep: "ImportEdgeTPU",
+        postElemID: "EdgeTPUInputPath",
       });
     });
 }

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -291,8 +291,32 @@ export function updateImportONNX() {
   });
 }
 
+function addEPostfixToFileName(filePath, postfix) {
+  const parts = filePath.split(".");
+  if (parts.length < 2) {
+    throw new Error("Invalid file ext");
+  }
+  const fileName = parts.slice(0, -1).join(".");
+  const fileExtension = parts[parts.length - 1];
+  const newFileName = `${fileName}${postfix}`;
+  const newFilePath = `${newFileName}.${fileExtension}`;
+
+  return newFilePath;
+}
+
 export function updateImportEdgeTPU() {
   let content = "";
+  content += iniKeyValueString(
+    "input_path",
+    document.getElementById("EdgeTPUInputPath").value
+  );
+  content += iniKeyValueString(
+    "output_path",
+    addEPostfixToFileName(
+      document.getElementById("EdgeTPUInputPath").value,
+      "_edgetpu"
+    )
+  );
   postMessageToVsCode({
     type: "setSection",
     section: "one-import-edgetpu",

--- a/src/CfgEditor/CfgData.ts
+++ b/src/CfgEditor/CfgData.ts
@@ -22,6 +22,7 @@ const sections = [
   "one-import-tflite",
   "one-import-bcq",
   "one-import-onnx",
+  "one-import-edgetpu",
   "one-optimize",
   "one-quantize",
   "one-codegen",


### PR DESCRIPTION
- Implemented the ability to input the path as either text or via a dialog.
- Disabled the output path functionality.
- Modified the output path to append "_edgetpu" as a postfix to the name of the .tflite file received from the input path.

ONE-vscode-DCO-1.0-Signed-off-by: Hyeon-Uk <rlagusdnr120@gmail.com>