### PR TITLE
[EdgeTPU] Add EdgeTPU Advanced Option 'Min Runtime Version' to cfgEditor

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -252,6 +252,57 @@ limitations under the License.
                         </span>
                     </span>
                 </div>
+                <div class="option">
+                    <div>
+                        Min Runtime Version (Optional)
+                        <span class="codicon codicon-question" style="cursor: pointer">
+                            <span class="help">
+                                Specify the lowest Edge TPU runtime version you want the model to be compatible with. <br />
+                                Version Information
+                                <table class="version-information">
+                                    <thead>
+                                        <tr>
+                                            <th> Compiler version </th>
+                                            <th> Runtime version </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>16.0</td>
+                                            <td>14</td>
+                                        </tr>
+                                        <tr>
+                                            <td>15.0</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>14.1</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.1.302470888</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.291256449</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.267685300</td>
+                                            <td>12</td>
+                                        </tr>
+                                        <tr>
+                                            <td>1.0</td>
+                                            <td>10</td>
+                                        </tr>
+                                    </tbody>
+                                </table>    
+                            </span>
+                        </span>
+                    </div>
+                    <vscode-dropdown id="EdgeTPUMinRuntimeVersion">   
+                    </vscode-dropdown>
+                </div>
             </div>
         </div>
         <div class="options" id="optionOptimize">

--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -217,14 +217,23 @@ limitations under the License.
                         <span class="help">
                             LSTM operation in ONNX file is unrolled so that there is no control flow in the graph
                         </span>
-                    </span>                    
+                    </span>                     
                 </div>
             </div>
             <div class="basic" id="optionImportEdgeTPUBasic">
                 <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
             </div>
             <div class="advanced" id="optionImportEdgeTPUAdvanced">
-                <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
+                <div class="option">
+                    <vscode-checkbox id="EdgeTPUShowOperations">
+                        Show Operations (Optional)
+                    </vscode-checkbox>  
+                    <span class="codicon codicon-question" style="cursor: pointer">
+                        <span class="help">
+                            Print the log showing operations that mapped to the Edge TPU.
+                        </span>
+                    </span>
+                </div>
             </div>
         </div>
         <div class="options" id="optionOptimize">

--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -84,6 +84,7 @@ limitations under the License.
                         <vscode-radio value="tflite">tflite</vscode-radio>
                         <vscode-radio value="onnx">onnx</vscode-radio>
                         <vscode-radio value="bcq" disabled="true">bcq</vscode-radio>
+                        <vscode-radio value="edgetpu">edge_tpu</vscode-radio>
                     </vscode-radio-group>
                 </div>
             </div>
@@ -218,6 +219,12 @@ limitations under the License.
                         </span>
                     </span>                    
                 </div>
+            </div>
+            <div class="basic" id="optionImportEdgeTPUBasic">
+                <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
+            </div>
+            <div class="advanced" id="optionImportEdgeTPUAdvanced">
+                <!-- 여기에 EdgeTPU Compile에 필요한 기본옵션을 추가하기 -->
             </div>
         </div>
         <div class="options" id="optionOptimize">

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -131,7 +131,6 @@ export function displayCfgToEditor(cfg) {
     oneImportONNX?.["output_path"]
   );
   document.getElementById("ONNXSaveIntermediate").checked = cfgBoolean(
-    // oneImportONNX?.["hoho_ho"]
     oneImportONNX?.["save_intermediate"]
   );
   document.getElementById("ONNXUnrollRNN").checked = cfgBoolean(

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -131,6 +131,7 @@ export function displayCfgToEditor(cfg) {
     oneImportONNX?.["output_path"]
   );
   document.getElementById("ONNXSaveIntermediate").checked = cfgBoolean(
+    // oneImportONNX?.["hoho_ho"]
     oneImportONNX?.["save_intermediate"]
   );
   document.getElementById("ONNXUnrollRNN").checked = cfgBoolean(
@@ -138,6 +139,11 @@ export function displayCfgToEditor(cfg) {
   );
   document.getElementById("ONNXUnrollLSTM").checked = cfgBoolean(
     oneImportONNX?.["unroll_lstm"]
+  );
+
+  const oneImportEDGETPU = cfg["one-import-edgetpu"];
+  document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
+    oneImportEDGETPU?.["show_operations"]
   );
 
   // TODO Support one-import-bcq

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -139,12 +139,6 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("ONNXUnrollLSTM").checked = cfgBoolean(
     oneImportONNX?.["unroll_lstm"]
   );
-
-  const oneImportEDGETPU = cfg["one-import-edgetpu"];
-  document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
-    oneImportEDGETPU?.["show_operations"]
-  );
-
   // TODO Support one-import-bcq
 
   // TODO Support import EdgeTPU
@@ -154,6 +148,13 @@ export function displayCfgToEditor(cfg) {
   );
   document.getElementById("EdgeTPUOutputPath").value = cfgString(
     oneImportEdgeTPU?.["output_path"]
+  );
+  document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
+    oneImportEdgeTPU?.["show_operations"]
+  );
+  document.getElementById("EdgeTPUMinRuntimeVersion").value = cfgString(
+    oneImportEdgeTPU?.["min_runtime_version"],
+    "14"
   );
 
   updateImportUI();

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -41,6 +41,9 @@ export function displayCfgToEditor(cfg) {
     } else if (onecc["one-import-bcq"] === "True") {
       document.getElementById("checkboxImport").checked = true;
       // TODO Enable when one-import-bcq is supported
+    } else if (onecc["one-import-edgetpu"] === "True") {
+      document.getElementById("checkboxImport").checked = true;
+      document.getElementById("importInputModelType").value = "edgetpu";
     } else {
       document.getElementById("checkboxImport").checked = false;
     }

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -336,7 +336,16 @@ function registerONNXOptions() {
   });
 }
 
-function registerEdgeTPUOptions() {}
+function registerEdgeTPUOptions() {
+  const edgeTPUShowOperations = document.getElementById(
+    "EdgeTPUShowOperations"
+  );
+
+  edgeTPUShowOperations.addEventListener("click", function () {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+}
 
 function registerOptimizeOptions() {
   const optimizeInputPath = document.getElementById("optimizeInputPath");

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -341,6 +341,9 @@ function registerEdgeTPUOptions() {
   const edgeTPUShowOperations = document.getElementById(
     "EdgeTPUShowOperations"
   );
+  const edgeTPUMinRuntimeVersion = document.getElementById(
+    "EdgeTPUMinRuntimeVersion"
+  );
   
   edgeTPUInputPath.addEventListener("input", function () {
     updateImportEdgeTPU();
@@ -350,6 +353,11 @@ function registerEdgeTPUOptions() {
   edgeTPUShowOperations.addEventListener("click", function () {
     updateImportEdgeTPU();
     applyUpdates();
+  });
+
+  edgeTPUMinRuntimeVersion.addEventListener("input", function () {
+    updateImportEdgeTPU();
+    applyUpdates();   
   });
 }
 

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -25,6 +25,7 @@ import {
   updateImportPB,
   updateImportSAVED,
   updateImportTFLITE,
+  updateImportEdgeTPU,
   updateOptimize,
   updateProfile,
   updateQuantizeActionType,
@@ -78,6 +79,9 @@ function main() {
             break;
           case "ImportONNX":
             updateImportONNX();
+            break;
+          case "ImportEdgeTPU":
+            updateImportEdgeTPU();
             break;
           case "Optimize":
             updateOptimize();
@@ -222,6 +226,7 @@ function registerImportOptions() {
   registerKERASOptions();
   registerTFLITEOptions();
   registerONNXOptions();
+  registerEdgeTPUOptions();
 }
 
 function registerPBOptions() {
@@ -330,6 +335,8 @@ function registerONNXOptions() {
     applyUpdates();
   });
 }
+
+function registerEdgeTPUOptions() {}
 
 function registerOptimizeOptions() {
   const optimizeInputPath = document.getElementById("optimizeInputPath");

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -321,6 +321,11 @@ export function updateImportEdgeTPU() {
     "show_operations",
     document.getElementById("EdgeTPUShowOperations").checked
   );
+  content += iniKeyValueString(
+    "min_runtime_version",
+    document.getElementById("EdgeTPUMinRuntimeVersion").value,    
+    "14"
+  );
 
   postMessageToVsCode({
     type: "setSection",

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -293,6 +293,11 @@ export function updateImportONNX() {
 
 export function updateImportEdgeTPU() {
   let content = "";
+  content += iniKeyValueString(
+    "show_operations",
+    document.getElementById("EdgeTPUShowOperations").checked
+  );
+
   postMessageToVsCode({
     type: "setSection",
     section: "one-import-edgetpu",

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -65,6 +65,12 @@ export function updateSteps() {
     param: "one-import-onnx",
     value: "False",
   });
+  postMessageToVsCode({
+    type: "setParam",
+    section: "onecc",
+    param: "one-import-edgetpu",
+    value: "False",
+  });
   if (document.getElementById("checkboxImport").checked) {
     switch (document.getElementById("importInputModelType").value) {
       case "pb":
@@ -90,6 +96,14 @@ export function updateSteps() {
           type: "setParam",
           section: "onecc",
           param: "one-import-onnx",
+          value: "True",
+        });
+        break;
+      case "edgetpu":
+        postMessageToVsCode({
+          type: "setParam",
+          section: "onecc",
+          param: "one-import-edgetpu",
           value: "True",
         });
         break;
@@ -148,6 +162,9 @@ export function updateImportInputModelType() {
       break;
     case "onnx":
       updateImportONNX();
+      break;
+    case "edgetpu":
+      updateImportEdgeTPU();
       break;
     default:
       break;
@@ -270,6 +287,15 @@ export function updateImportONNX() {
   postMessageToVsCode({
     type: "setSection",
     section: "one-import-onnx",
+    param: content,
+  });
+}
+
+export function updateImportEdgeTPU() {
+  let content = "";
+  postMessageToVsCode({
+    type: "setSection",
+    section: "one-import-edgetpu",
     param: content,
   });
 }

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -31,7 +31,10 @@ export function updateImportUI() {
   const edgeTPUAdvancedOptions = document.getElementById(
     "optionImportEdgeTPUAdvanced"
   );
+  const edgeTPUMinRuntimeVersion = document.getElementById("EdgeTPUMinRuntimeVersion");
 
+  const versionList = [10, 11, 12, 13, 14];
+  
   pbBasicOptions.style.display = "none";
   pbAdvancedOptions.style.display = "none";
   savedBasicOptions.style.display = "none";
@@ -61,6 +64,12 @@ export function updateImportUI() {
       onnxAdvancedOptions.style.display = "block";
       break;
     case "edgetpu":
+      if(edgeTPUMinRuntimeVersion.childElementCount !== versionList.length){
+        versionList.forEach(version => {
+          var option = new Option(version); 
+          edgeTPUMinRuntimeVersion.append(option);
+        });
+      }
       edgeTPUBasicOptions.style.display = "block";
       edgeTPUAdvancedOptions.style.display = "block";
       break;

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -25,6 +25,12 @@ export function updateImportUI() {
   const onnxAdvancedOptions = document.getElementById(
     "optionImportONNXAdvanced"
   );
+  const edgeTPUBasicOptions = document.getElementById(
+    "optionImportEdgeTPUBasic"
+  );
+  const edgeTPUAdvancedOptions = document.getElementById(
+    "optionImportEdgeTPUAdvanced"
+  );
 
   pbBasicOptions.style.display = "none";
   pbAdvancedOptions.style.display = "none";
@@ -33,6 +39,8 @@ export function updateImportUI() {
   tfliteBasicOptions.style.display = "none";
   onnxBasicOptions.style.display = "none";
   onnxAdvancedOptions.style.display = "none";
+  edgeTPUBasicOptions.style.display = "none";
+  edgeTPUAdvancedOptions.style.display = "none";
 
   switch (modelType.value) {
     case "pb":
@@ -51,6 +59,10 @@ export function updateImportUI() {
     case "onnx":
       onnxBasicOptions.style.display = "block";
       onnxAdvancedOptions.style.display = "block";
+      break;
+    case "edgetpu":
+      edgeTPUBasicOptions.style.display = "block";
+      edgeTPUAdvancedOptions.style.display = "block";
       break;
     default:
       break;

--- a/src/CfgEditor/CfgData.ts
+++ b/src/CfgEditor/CfgData.ts
@@ -22,6 +22,7 @@ const sections = [
   "one-import-tflite",
   "one-import-bcq",
   "one-import-onnx",
+  "one-import-edgetpu",
   "one-optimize",
   "one-quantize",
   "one-codegen",


### PR DESCRIPTION
- Implemented Min Runtime Version dropdown on View
- There are only 5 versions in Documents
- On 'help', add description about compiler and runtime version
- Not Styled Version, Only function

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>