### PR TITLE
[EdgeTPU] Add EdgeTPUCompiler

### DIFF
--- a/src/Backend/Version.ts
+++ b/src/Backend/Version.ts
@@ -23,7 +23,7 @@ class Version {
   constructor(
     major: number,
     minor: number | undefined,
-    patch: number | undefined,
+    patch?: number | undefined,
     option: string = ""
   ) {
     this.major = major;


### PR DESCRIPTION
- Implemented the EdgeTPUCompiler for EdgeTPUToolchain
- Implemented the following functions in EdgeTPUCompiler
  - getToolchainTypes
  - parseVersion
  - getToolchains
  - getInstalledToolchains
  - prerequisitesForGetToolchains
- Change patch of Version to optional parameter

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>