### PR TITLE
[EdgeTPU] Add Advanced Option 'Delegate Search Step' to cfgEditor

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -262,6 +262,57 @@ limitations under the License.
                             Print the log showing operations that mapped to the Edge TPU.
                         </span>
                     </span>
+                </div>               
+                <div class="option">
+                    <div>
+                        Min Runtime Version (Optional)
+                        <span class="codicon codicon-question" style="cursor: pointer">
+                            <span class="help">
+                                Specify the lowest Edge TPU runtime version you want the model to be compatible with. <br />
+                                Version Information
+                                <table class="version-information">
+                                    <thead>
+                                        <tr>
+                                            <th> Compiler version </th>
+                                            <th> Runtime version </th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        <tr>
+                                            <td>16.0</td>
+                                            <td>14</td>
+                                        </tr>
+                                        <tr>
+                                            <td>15.0</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>14.1</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.1.302470888</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.291256449</td>
+                                            <td>13</td>
+                                        </tr>
+                                        <tr>
+                                            <td>2.0.267685300</td>
+                                            <td>12</td>
+                                        </tr>
+                                        <tr>
+                                            <td>1.0</td>
+                                            <td>10</td>
+                                        </tr>
+                                    </tbody>
+                                </table>    
+                            </span>
+                        </span>
+                    </div>
+                    <vscode-dropdown id="EdgeTPUMinRuntimeVersion">   
+                    </vscode-dropdown>
                 </div>
                 <div class="option">
                     <vscode-checkbox id="EdgeTPUSearchDelegate">

--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -316,11 +316,22 @@ limitations under the License.
                 </div>
                 <div class="option">
                     <vscode-checkbox id="EdgeTPUSearchDelegate">
-                        Search Delegate
+                        Search Delegate (Optional)
                     </vscode-checkbox>
                     <span class="codicon codicon-question" style="cursor: pointer">
                         <span class="help">
                             Enable repeated search for a new compilation stopping point earlier in the graph, to avoid rare compiler failures when it encounters an unsupported operation.
+                        </span>
+                    </span>
+                </div>
+                <div class="option" id="EdgeTPUDelegateSearchStepDiv">
+                    <vscode-text-field type="number" id="EdgeTPUDelegateSearchStep" value="1">
+                        Delegate Search Step (Optional)
+                    </vscode-text-field>
+                    <span class="codicon codicon-question" style="cursor: pointer">
+                        <span class="help">
+                            Specify a step size (the number of ops to move backward) <br />
+                            Default size is 1 and the mindest size is also 1.
                         </span>
                     </span>
                 </div>

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -153,6 +153,21 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("EdgeTPUHelp").checked = cfgBoolean(
     oneImportEdgeTPU?.["help"]
   );
+  document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
+    oneImportEdgeTPU?.["show_operations"]
+  );
+  document.getElementById("EdgeTPUMinRuntimeVersion").value = cfgString(
+    oneImportEdgeTPU?.["min_runtime_version"],
+    "14"
+  );
+  document.getElementById("EdgeTPUSearchDelegate").checked = cfgBoolean(
+    oneImportEdgeTPU?.["search_delegate"]
+  );
+  document.getElementById("EdgeTPUDelegateSearchStep").value = cfgString(
+    oneImportEdgeTPU?.["delegate_search_step"],
+    1
+  );
+
 
   updateImportUI();
 
@@ -290,6 +305,7 @@ export function displayCfgToEditor(cfg) {
   );
 }
 
+
 function cfgString(str, defaultStr = "") {
   if (str === null || str === undefined) {
     return defaultStr;
@@ -308,3 +324,4 @@ function cfgBoolean(str) {
 
   return false;
 }
+

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -139,7 +139,7 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("ONNXUnrollLSTM").checked = cfgBoolean(
     oneImportONNX?.["unroll_lstm"]
   );
-  
+
   // TODO Support one-import-bcq
 
   // TODO Support import EdgeTPU
@@ -149,7 +149,7 @@ export function displayCfgToEditor(cfg) {
   );
   document.getElementById("EdgeTPUOutputPath").value = cfgString(
     oneImportEdgeTPU?.["output_path"]
-  );  
+  );
   document.getElementById("EdgeTPUHelp").checked = cfgBoolean(
     oneImportEdgeTPU?.["help"]
   );
@@ -167,7 +167,6 @@ export function displayCfgToEditor(cfg) {
     oneImportEdgeTPU?.["delegate_search_step"],
     "1"
   );
-
 
   updateImportUI();
 
@@ -305,7 +304,6 @@ export function displayCfgToEditor(cfg) {
   );
 }
 
-
 function cfgString(str, defaultStr = "") {
   if (str === null || str === undefined) {
     return defaultStr;
@@ -324,4 +322,3 @@ function cfgBoolean(str) {
 
   return false;
 }
-

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -165,7 +165,7 @@ export function displayCfgToEditor(cfg) {
   );
   document.getElementById("EdgeTPUDelegateSearchStep").value = cfgString(
     oneImportEdgeTPU?.["delegate_search_step"],
-    1
+    "1"
   );
 
 

--- a/media/CfgEditor/displaycfg.js
+++ b/media/CfgEditor/displaycfg.js
@@ -139,7 +139,7 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("ONNXUnrollLSTM").checked = cfgBoolean(
     oneImportONNX?.["unroll_lstm"]
   );
-
+  
   // TODO Support one-import-bcq
 
   // TODO Support import EdgeTPU
@@ -149,14 +149,11 @@ export function displayCfgToEditor(cfg) {
   );
   document.getElementById("EdgeTPUOutputPath").value = cfgString(
     oneImportEdgeTPU?.["output_path"]
-  );
+  );  
   document.getElementById("EdgeTPUHelp").checked = cfgBoolean(
     oneImportEdgeTPU?.["help"]
   );
-  document.getElementById("EdgeTPUSearchDelegate").checked = cfgBoolean(
-    oneImportEdgeTPU?.["search_delegate"]
-  );
-  
+
   updateImportUI();
 
   const oneOptimize = cfg["one-optimize"];

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -382,7 +382,7 @@ function registerEdgeTPUOptions() {
   });
   edgeTPUDelegateSearchStep.addEventListener("input", function () {
     edgeTPUDelegateSearchStep.value =
-      edgeTPUDelegateSearchStep.value * 1 < 1
+      edgeTPUDelegateSearchStep.value < 1
         ? "1"
         : edgeTPUDelegateSearchStep.value;
     updateImportEdgeTPU();

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -342,10 +342,13 @@ function registerEdgeTPUOptions() {
   const edgeTPUShowOperations = document.getElementById(
     "EdgeTPUShowOperations"
   );
+  const edgeTPUMinRuntimeVersion = document.getElementById(
+    "EdgeTPUMinRuntimeVersion"
+  );  
   const edgeTPUSearchDelegate = document.getElementById(
     "EdgeTPUSearchDelegate"
   );
-
+  
   edgeTPUInputPath.addEventListener("input", function () {
     updateImportEdgeTPU();
     applyUpdates();
@@ -358,7 +361,11 @@ function registerEdgeTPUOptions() {
     updateImportEdgeTPU();
     applyUpdates();
   });
-  edgeTPUSearchDelegate.addEventListener("click", function () {
+  edgeTPUMinRuntimeVersion.addEventListener("click", function() {
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUSearchDelegate.addEventListener("click", function(){
     updateImportEdgeTPU();
     applyUpdates();
   });

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -336,7 +336,7 @@ function registerONNXOptions() {
   });
 }
 
-function registerEdgeTPUOptions() {
+function registerEdgeTPUOptions() {  
   const edgeTPUInputPath = document.getElementById("EdgeTPUInputPath");
   const edgeTPUHelp = document.getElementById("EdgeTPUHelp");
   const edgeTPUShowOperations = document.getElementById(
@@ -347,6 +347,12 @@ function registerEdgeTPUOptions() {
   );  
   const edgeTPUSearchDelegate = document.getElementById(
     "EdgeTPUSearchDelegate"
+  );
+  const edgeTPUDelegateSearchStep = document.getElementById(
+    "EdgeTPUDelegateSearchStep"
+  );
+  const edgeTPUDelegateSearchStepDiv = document.getElementById(
+    "EdgeTPUDelegateSearchStepDiv"
   );
   
   edgeTPUInputPath.addEventListener("input", function () {
@@ -361,15 +367,23 @@ function registerEdgeTPUOptions() {
     updateImportEdgeTPU();
     applyUpdates();
   });
-  edgeTPUMinRuntimeVersion.addEventListener("click", function() {
+  edgeTPUMinRuntimeVersion.addEventListener("input", function () {
     updateImportEdgeTPU();
     applyUpdates();
   });
-  edgeTPUSearchDelegate.addEventListener("click", function(){
+  edgeTPUSearchDelegate.addEventListener("click", function(){    
+    if(edgeTPUSearchDelegate.checked) {edgeTPUDelegateSearchStepDiv.style.display = "block";}
+    else {edgeTPUDelegateSearchStepDiv.style.display = "none";}
+    updateImportEdgeTPU();
+    applyUpdates();
+  });
+  edgeTPUDelegateSearchStep.addEventListener("input", function(){
+    edgeTPUDelegateSearchStep.value = edgeTPUDelegateSearchStep.value * 1 < 1 ? 1 : edgeTPUDelegateSearchStep.value;
     updateImportEdgeTPU();
     applyUpdates();
   });
 }
+
 
 function registerOptimizeOptions() {
   const optimizeInputPath = document.getElementById("optimizeInputPath");

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -336,7 +336,7 @@ function registerONNXOptions() {
   });
 }
 
-function registerEdgeTPUOptions() {  
+function registerEdgeTPUOptions() {
   const edgeTPUInputPath = document.getElementById("EdgeTPUInputPath");
   const edgeTPUHelp = document.getElementById("EdgeTPUHelp");
   const edgeTPUShowOperations = document.getElementById(
@@ -344,7 +344,7 @@ function registerEdgeTPUOptions() {
   );
   const edgeTPUMinRuntimeVersion = document.getElementById(
     "EdgeTPUMinRuntimeVersion"
-  );  
+  );
   const edgeTPUSearchDelegate = document.getElementById(
     "EdgeTPUSearchDelegate"
   );
@@ -354,7 +354,7 @@ function registerEdgeTPUOptions() {
   const edgeTPUDelegateSearchStepDiv = document.getElementById(
     "EdgeTPUDelegateSearchStepDiv"
   );
-  
+
   edgeTPUInputPath.addEventListener("input", function () {
     updateImportEdgeTPU();
     applyUpdates();
@@ -371,19 +371,24 @@ function registerEdgeTPUOptions() {
     updateImportEdgeTPU();
     applyUpdates();
   });
-  edgeTPUSearchDelegate.addEventListener("click", function(){    
-    if(edgeTPUSearchDelegate.checked) {edgeTPUDelegateSearchStepDiv.style.display = "block";}
-    else {edgeTPUDelegateSearchStepDiv.style.display = "none";}
+  edgeTPUSearchDelegate.addEventListener("click", function () {
+    if (edgeTPUSearchDelegate.checked) {
+      edgeTPUDelegateSearchStepDiv.style.display = "block";
+    } else {
+      edgeTPUDelegateSearchStepDiv.style.display = "none";
+    }
     updateImportEdgeTPU();
     applyUpdates();
   });
-  edgeTPUDelegateSearchStep.addEventListener("input", function(){
-    edgeTPUDelegateSearchStep.value = edgeTPUDelegateSearchStep.value * 1 < 1 ? "1" : edgeTPUDelegateSearchStep.value;
+  edgeTPUDelegateSearchStep.addEventListener("input", function () {
+    edgeTPUDelegateSearchStep.value =
+      edgeTPUDelegateSearchStep.value * 1 < 1
+        ? "1"
+        : edgeTPUDelegateSearchStep.value;
     updateImportEdgeTPU();
     applyUpdates();
   });
 }
-
 
 function registerOptimizeOptions() {
   const optimizeInputPath = document.getElementById("optimizeInputPath");

--- a/media/CfgEditor/index.js
+++ b/media/CfgEditor/index.js
@@ -378,7 +378,7 @@ function registerEdgeTPUOptions() {
     applyUpdates();
   });
   edgeTPUDelegateSearchStep.addEventListener("input", function(){
-    edgeTPUDelegateSearchStep.value = edgeTPUDelegateSearchStep.value * 1 < 1 ? 1 : edgeTPUDelegateSearchStep.value;
+    edgeTPUDelegateSearchStep.value = edgeTPUDelegateSearchStep.value * 1 < 1 ? "1" : edgeTPUDelegateSearchStep.value;
     updateImportEdgeTPU();
     applyUpdates();
   });

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -338,6 +338,10 @@ export function updateImportEdgeTPU() {
   content += iniKeyValueString(
     "search_delegate",
     document.getElementById("EdgeTPUSearchDelegate").checked
+  );  
+  content += iniKeyValueString(
+    "delegate_search_step",
+    document.getElementById("EdgeTPUSearchDelegate").checked ? (document.getElementById("EdgeTPUDelegateSearchStep").value < 1 ? 1 : document.getElementById("EdgeTPUDelegateSearchStep").value) : undefined
   );
 
   postMessageToVsCode({

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -291,15 +291,20 @@ export function updateImportONNX() {
   });
 }
 
-function addPostfixToFileName(filePath, postfix = "") {
-  const parts = filePath.split(".");
-  if (parts.length < 2) {
-    throw new Error("Invalid file ext");
+function addPostfixToFileName(filePath = "", postfix = "") {
+  if (filePath.trim() === "") {
+    return "";
   }
-  const fileName = parts.slice(0, -1).join(".");
-  const fileExtension = parts[parts.length - 1];
-  const newFileName = `${fileName}${postfix}`;
-  const newFilePath = `${newFileName}.${fileExtension}`;
+  const parts = filePath.split(".");
+  let newFilePath = "";
+  if (parts.length < 2) {
+    newFilePath = `${filePath}${postfix}`;
+  } else {
+    const fileName = parts.slice(0, -1).join(".");
+    const fileExtension = parts[parts.length - 1];
+    const newFileName = `${fileName}${postfix}`;
+    newFilePath = `${newFileName}.${fileExtension}`;
+  }
 
   return newFilePath;
 }
@@ -326,10 +331,14 @@ export function updateImportEdgeTPU() {
     document.getElementById("EdgeTPUShowOperations").checked
   );
   content += iniKeyValueString(
+    "min_runtime_version",
+    document.getElementById("EdgeTPUMinRuntimeVersion").value,    
+    "14"
+  );
+  content += iniKeyValueString(
     "search_delegate",
     document.getElementById("EdgeTPUSearchDelegate").checked
   );
-
 
   postMessageToVsCode({
     type: "setSection",

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -332,16 +332,20 @@ export function updateImportEdgeTPU() {
   );
   content += iniKeyValueString(
     "min_runtime_version",
-    document.getElementById("EdgeTPUMinRuntimeVersion").value,    
+    document.getElementById("EdgeTPUMinRuntimeVersion").value,
     "14"
   );
   content += iniKeyValueString(
     "search_delegate",
     document.getElementById("EdgeTPUSearchDelegate").checked
-  );  
+  );
   content += iniKeyValueString(
     "delegate_search_step",
-    document.getElementById("EdgeTPUSearchDelegate").checked ? (document.getElementById("EdgeTPUDelegateSearchStep").value < 1 ? "1" : document.getElementById("EdgeTPUDelegateSearchStep").value) : undefined
+    document.getElementById("EdgeTPUSearchDelegate").checked
+      ? document.getElementById("EdgeTPUDelegateSearchStep").value < 1
+        ? "1"
+        : document.getElementById("EdgeTPUDelegateSearchStep").value
+      : undefined
   );
 
   postMessageToVsCode({

--- a/media/CfgEditor/updateContent.js
+++ b/media/CfgEditor/updateContent.js
@@ -341,7 +341,7 @@ export function updateImportEdgeTPU() {
   );  
   content += iniKeyValueString(
     "delegate_search_step",
-    document.getElementById("EdgeTPUSearchDelegate").checked ? (document.getElementById("EdgeTPUDelegateSearchStep").value < 1 ? 1 : document.getElementById("EdgeTPUDelegateSearchStep").value) : undefined
+    document.getElementById("EdgeTPUSearchDelegate").checked ? (document.getElementById("EdgeTPUDelegateSearchStep").value < 1 ? "1" : document.getElementById("EdgeTPUDelegateSearchStep").value) : undefined
   );
 
   postMessageToVsCode({

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -31,12 +31,18 @@ export function updateImportUI() {
   const edgeTPUAdvancedOptions = document.getElementById(
     "optionImportEdgeTPUAdvanced"
   );
-  const edgeTPUMinRuntimeVersion = document.getElementById("EdgeTPUMinRuntimeVersion");
-  const edgeTPUSearchDelegate = document.getElementById("EdgeTPUSearchDelegate");
-  const edgeTPUDelegateSearchStepDiv = document.getElementById("EdgeTPUDelegateSearchStepDiv");
+  const edgeTPUMinRuntimeVersion = document.getElementById(
+    "EdgeTPUMinRuntimeVersion"
+  );
+  const edgeTPUSearchDelegate = document.getElementById(
+    "EdgeTPUSearchDelegate"
+  );
+  const edgeTPUDelegateSearchStepDiv = document.getElementById(
+    "EdgeTPUDelegateSearchStepDiv"
+  );
 
   const versionList = [10, 11, 12, 13, 14];
-  
+
   pbBasicOptions.style.display = "none";
   pbAdvancedOptions.style.display = "none";
   savedBasicOptions.style.display = "none";
@@ -68,13 +74,15 @@ export function updateImportUI() {
       onnxAdvancedOptions.style.display = "block";
       break;
     case "edgetpu":
-      if(edgeTPUMinRuntimeVersion.childElementCount !== versionList.length){
-        versionList.forEach(version => {
-          var option = new Option(version); 
+      if (edgeTPUMinRuntimeVersion.childElementCount !== versionList.length) {
+        versionList.forEach((version) => {
+          var option = new Option(version);
           edgeTPUMinRuntimeVersion.append(option);
         });
-      } 
-      edgeTPUDelegateSearchStepDiv.style.display = edgeTPUSearchDelegate.checked ? "block" : "none";
+      }
+      edgeTPUDelegateSearchStepDiv.style.display = edgeTPUSearchDelegate.checked
+        ? "block"
+        : "none";
       edgeTPUBasicOptions.style.display = "block";
       edgeTPUAdvancedOptions.style.display = "block";
       break;

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -32,6 +32,8 @@ export function updateImportUI() {
     "optionImportEdgeTPUAdvanced"
   );
   const edgeTPUMinRuntimeVersion = document.getElementById("EdgeTPUMinRuntimeVersion");
+  const edgeTPUSearchDelegate = document.getElementById("EdgeTPUSearchDelegate");
+  const edgeTPUDelegateSearchStepDiv = document.getElementById("EdgeTPUDelegateSearchStepDiv");
 
   const versionList = [10, 11, 12, 13, 14];
   
@@ -44,6 +46,8 @@ export function updateImportUI() {
   onnxAdvancedOptions.style.display = "none";
   edgeTPUBasicOptions.style.display = "none";
   edgeTPUAdvancedOptions.style.display = "none";
+  // edgeTPUDelegateSearchStepDiv.style.display = "none";
+  // edgeTPUDelegateSearchStepDiv.style.display = edgeTPUDelegateSearchStep.checked ? "block" : "none";
 
   switch (modelType.value) {
     case "pb":
@@ -69,7 +73,8 @@ export function updateImportUI() {
           var option = new Option(version); 
           edgeTPUMinRuntimeVersion.append(option);
         });
-      }
+      } 
+      edgeTPUDelegateSearchStepDiv.style.display = edgeTPUSearchDelegate.checked ? "block" : "none";
       edgeTPUBasicOptions.style.display = "block";
       edgeTPUAdvancedOptions.style.display = "block";
       break;

--- a/media/CfgEditor/updateUI.js
+++ b/media/CfgEditor/updateUI.js
@@ -31,7 +31,10 @@ export function updateImportUI() {
   const edgeTPUAdvancedOptions = document.getElementById(
     "optionImportEdgeTPUAdvanced"
   );
+  const edgeTPUMinRuntimeVersion = document.getElementById("EdgeTPUMinRuntimeVersion");
 
+  const versionList = [10, 11, 12, 13, 14];
+  
   pbBasicOptions.style.display = "none";
   pbAdvancedOptions.style.display = "none";
   savedBasicOptions.style.display = "none";
@@ -61,6 +64,12 @@ export function updateImportUI() {
       onnxAdvancedOptions.style.display = "block";
       break;
     case "edgetpu":
+      if(edgeTPUMinRuntimeVersion.childElementCount !== versionList.length){
+        versionList.forEach(version => {
+          var option = new Option(version); 
+          edgeTPUMinRuntimeVersion.append(option);
+        });
+      }
       edgeTPUBasicOptions.style.display = "block";
       edgeTPUAdvancedOptions.style.display = "block";
       break;


### PR DESCRIPTION
- Implemented Delegate Search Step in cfgEditor with number type of vscode-text-field
- This option is depending on 'Search Delegate'.
- When 'Search Delegate' is checked, the text-field for this option is shown.
- When 'Search Delegate' is unchecked, the text-field for this option is not shown and this opiton is also removed on the cfg text file.

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>