### PR TITLE
[EdgeTPU] HotFix Remove the word, Optional, in each Advanced Options

### DIFF
--- a/media/CfgEditor/cfgeditor.html
+++ b/media/CfgEditor/cfgeditor.html
@@ -250,7 +250,7 @@ limitations under the License.
                 </div>
                 <div class="option">
                     <vscode-checkbox id="EdgeTPUShowOperations">
-                        Show Operations (Optional)
+                        Show Operations
                     </vscode-checkbox>  
                     <span class="codicon codicon-question" style="cursor: pointer">
                         <span class="help">
@@ -260,7 +260,7 @@ limitations under the License.
                 </div>               
                 <div class="option">
                     <div>
-                        Min Runtime Version (Optional)
+                        Min Runtime Version
                         <span class="codicon codicon-question" style="cursor: pointer">
                             <span class="help">
                                 Specify the lowest Edge TPU runtime version you want the model to be compatible with. <br />
@@ -311,7 +311,7 @@ limitations under the License.
                 </div>
                 <div class="option">
                     <vscode-checkbox id="EdgeTPUSearchDelegate">
-                        Search Delegate (Optional)
+                        Search Delegate
                     </vscode-checkbox>
                     <span class="codicon codicon-question" style="cursor: pointer">
                         <span class="help">
@@ -321,7 +321,7 @@ limitations under the License.
                 </div>
                 <div class="option" id="EdgeTPUDelegateSearchStepDiv">
                     <vscode-text-field type="number" id="EdgeTPUDelegateSearchStep" value="1">
-                        Delegate Search Step (Optional)
+                        Delegate Search Step
                     </vscode-text-field>
                     <span class="codicon codicon-question" style="cursor: pointer">
                         <span class="help">


### PR DESCRIPTION
- We assume all advanced options are the optional that means the compiler will be run even there is no value in the options.
- Remove the word 'Optional' after Show Operations, Min Runtime Version, Search Delegate and Delegate Search Step

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>