### PR TITLE
[EdgeTPU] Fix the process setting '--out_dir' option value from the c…

### DIFF
--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -18,6 +18,7 @@ import * as cp from "child_process";
 import * as vscode from "vscode";
 import * as ini from "ini";
 import * as fs from "fs";
+import * as path from "path";
 
 import { pipedSpawnSync } from "../../Utils/PipedSpawnSync";
 import { Backend } from "../Backend";
@@ -37,9 +38,9 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
       return cmd;
     }
 
-    let outputPath = config["one-import-edgetpu"]["output_path"];
+    let outDir = path.dirname(config["one-import-edgetpu"]["output_path"]);
     cmd.push("--out_dir");
-    cmd.push(outputPath);
+    cmd.push(outDir);
 
     let help = config["one-import-edgetpu"]["help"];
     if (help === "True") {

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -48,6 +48,18 @@ search_delegate=True
 delegate_search_step=4
 `;
 
+const relativeOutputPathcontent = `
+[one-import-edgetpu]
+input_path=./sample.tflite
+output_path=./sample_edge_tpu.tflite
+help=True
+intermediate_tensors=tensorName1,tensorName2
+show_operations=True
+min_runtime_version=14
+search_delegate=True
+delegate_search_step=4
+`;
+
 suite("Backend", function () {
   suite("EdgeTPUDebianToolchain", function () {
     let testBuilder: TestBuilder;
@@ -76,7 +88,7 @@ suite("Backend", function () {
         const expectedStrs: string[] = [
           "edgetpu_compiler",
           "--out_dir",
-          "/home/workspace/models/sample_edge_tpu.tflite",
+          "/home/workspace/models",
           "--help",
           "--intermediate_tensors",
           "tensorName1,tensorName2",
@@ -87,6 +99,36 @@ suite("Backend", function () {
           "--delegate_search_step",
           "4",
           "/home/workspace/models/sample.tflite",
+        ];
+
+        assert.deepEqual(cmd, expectedStrs);
+      });
+
+      test("returns Command with cfg containing relative input path", function () {
+        testBuilder.writeFileSync("file.cfg", relativeOutputPathcontent);
+        const cfgFilePath = testBuilder.getPath("file.cfg");
+
+        const name = "EdgeTPU";
+        const desc = "EdgeTPU Compiler";
+        const version = new Version(0, 1, 0);
+        const info = new ToolchainInfo(name, desc, version);
+        let dt = new EdgeTPUDebianToolchain(info);
+        let cmd = dt.run(cfgFilePath);
+
+        const expectedStrs: string[] = [
+          "edgetpu_compiler",
+          "--out_dir",
+          ".",
+          "--help",
+          "--intermediate_tensors",
+          "tensorName1,tensorName2",
+          "--show_operations",
+          "--min_runtime_version",
+          "14",
+          "--search_delegate",
+          "--delegate_search_step",
+          "4",
+          "./sample.tflite",
         ];
 
         assert.deepEqual(cmd, expectedStrs);


### PR DESCRIPTION
…fg file

- The option '--out_dir' of edgetpu_compiler needs a directory, not a file path.
- To fix the process it uses path module to get a directory from a input file path.

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>