### PR TITLE
[EdgeTPU] Remove --help option

### DIFF
--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -42,11 +42,6 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     cmd.push("--out_dir");
     cmd.push(outDir);
 
-    let help = config["one-import-edgetpu"]["help"];
-    if (help === "True") {
-      cmd.push("--help");
-    }
-
     let intermediateTensors =
       config["one-import-edgetpu"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -40,7 +40,6 @@ input_model_dtype=uint8
 [one-import-edgetpu]
 input_path=/home/workspace/models/sample.tflite
 output_path=/home/workspace/models/sample_edge_tpu.tflite
-help=True
 intermediate_tensors=tensorName1,tensorName2
 show_operations=True
 min_runtime_version=14
@@ -52,7 +51,6 @@ const relativeOutputPathcontent = `
 [one-import-edgetpu]
 input_path=./sample.tflite
 output_path=./sample_edge_tpu.tflite
-help=True
 intermediate_tensors=tensorName1,tensorName2
 show_operations=True
 min_runtime_version=14
@@ -89,7 +87,6 @@ suite("Backend", function () {
           "edgetpu_compiler",
           "--out_dir",
           "/home/workspace/models",
-          "--help",
           "--intermediate_tensors",
           "tensorName1,tensorName2",
           "--show_operations",
@@ -119,7 +116,6 @@ suite("Backend", function () {
           "edgetpu_compiler",
           "--out_dir",
           ".",
-          "--help",
           "--intermediate_tensors",
           "tensorName1,tensorName2",
           "--show_operations",


### PR DESCRIPTION
This commit removes the --help option as edgetpu_compiler doesn't compile a model with the --help option.

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>