### PR TITLE
[EdgeTPU] Remove the Option - Min Runtime Version

### DIFF
--- a/media/EdgetpuCfgEditor/cfgeditor.html
+++ b/media/EdgetpuCfgEditor/cfgeditor.html
@@ -101,57 +101,6 @@ limitations under the License.
                             Print the log showing operations that mapped to the Edge TPU.
                         </span>
                     </span>
-                </div>  
-                <div class="option">
-                    <div>
-                        Min Runtime Version
-                        <span class="codicon codicon-question" style="cursor: pointer">
-                            <span class="help">
-                                Specify the lowest Edge TPU runtime version you want the model to be compatible with. <br />
-                                Version Information
-                                <table class="version-information">
-                                    <thead>
-                                        <tr>
-                                            <th> Compiler version </th>
-                                            <th> Runtime version </th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        <tr>
-                                            <td>16.0</td>
-                                            <td>14</td>
-                                        </tr>
-                                        <tr>
-                                            <td>15.0</td>
-                                            <td>13</td>
-                                        </tr>
-                                        <tr>
-                                            <td>14.1</td>
-                                            <td>13</td>
-                                        </tr>
-                                        <tr>
-                                            <td>2.1.302470888</td>
-                                            <td>13</td>
-                                        </tr>
-                                        <tr>
-                                            <td>2.0.291256449</td>
-                                            <td>13</td>
-                                        </tr>
-                                        <tr>
-                                            <td>2.0.267685300</td>
-                                            <td>12</td>
-                                        </tr>
-                                        <tr>
-                                            <td>1.0</td>
-                                            <td>10</td>
-                                        </tr>
-                                    </tbody>
-                                </table>    
-                            </span>
-                        </span>
-                    </div>
-                    <vscode-dropdown id="EdgeTPUMinRuntimeVersion">   
-                    </vscode-dropdown>
                 </div>
                 <div class="option">
                     <vscode-checkbox id="EdgeTPUSearchDelegate">

--- a/media/EdgetpuCfgEditor/displaycfg.js
+++ b/media/EdgetpuCfgEditor/displaycfg.js
@@ -27,10 +27,6 @@ export function displayCfgToEditor(cfg) {
   document.getElementById("EdgeTPUShowOperations").checked = cfgBoolean(
     edgeTPUCompiler?.["show_operations"]
   );
-  document.getElementById("EdgeTPUMinRuntimeVersion").value = cfgString(
-    edgeTPUCompiler?.["min_runtime_version"],
-    "14"
-  );
   document.getElementById("EdgeTPUSearchDelegate").checked = cfgBoolean(
     edgeTPUCompiler?.["search_delegate"]
   );

--- a/media/EdgetpuCfgEditor/index.js
+++ b/media/EdgetpuCfgEditor/index.js
@@ -108,9 +108,6 @@ function registerCompileOptions() {
   const edgeTPUShowOperations = document.getElementById(
     "EdgeTPUShowOperations"
   );
-  const edgeTPUMinRuntimeVersion = document.getElementById(
-    "EdgeTPUMinRuntimeVersion"
-  );
   const edgeTPUSearchDelegate = document.getElementById(
     "EdgeTPUSearchDelegate"
   );
@@ -133,10 +130,6 @@ function registerCompileOptions() {
     applyUpdates();
   });
   edgeTPUShowOperations.addEventListener("click", function () {
-    updateEdgeTPUCompile();
-    applyUpdates();
-  });
-  edgeTPUMinRuntimeVersion.addEventListener("input", function () {
     updateEdgeTPUCompile();
     applyUpdates();
   });

--- a/media/EdgetpuCfgEditor/index.js
+++ b/media/EdgetpuCfgEditor/index.js
@@ -18,11 +18,9 @@ import { displayCfgToEditor } from "./displaycfg.js";
 import {
   applyUpdates,
   updateEdgeTPUStep,
-  updateEdgeTPUCompile
+  updateEdgeTPUCompile,
 } from "./updateContent.js";
-import {
-  updateStepUI,
-} from "./updateUI.js";
+import { updateStepUI } from "./updateUI.js";
 import { postMessageToVsCode } from "./vscodeapi.js";
 
 // Just like a regular webpage we need to wait for the webview
@@ -47,7 +45,7 @@ function main() {
         break;
       case "applyDialogPath":
         document.getElementById(message.elemID).value = message.path;
-        switch (message.step) {          
+        switch (message.step) {
           case "EdgeTPUCompile":
             updateEdgeTPUCompile();
             break;
@@ -78,20 +76,24 @@ function setDefaultValues(name) {
 }
 
 function registerCompilerStep() {
-  const checkboxEdgeTPUCompile = document.getElementById("checkboxEdgeTPUCompile");
-  const checkboxEdgeTPUProfile = document.getElementById("checkboxEdgeTPUProfile");
+  const checkboxEdgeTPUCompile = document.getElementById(
+    "checkboxEdgeTPUCompile"
+  );
+  const checkboxEdgeTPUProfile = document.getElementById(
+    "checkboxEdgeTPUProfile"
+  );
   const stepEdgeTPUCompile = document.getElementById("stepEdgeTPUCompile");
   const stepEdgeTPUProfile = document.getElementById("stepEdgeTPUProfile");
 
   checkboxEdgeTPUCompile.addEventListener("click", function () {
-    updateEdgeTPUStep();    
+    updateEdgeTPUStep();
     applyUpdates();
   });
   checkboxEdgeTPUProfile.addEventListener("click", function () {
-    updateEdgeTPUStep();    
+    updateEdgeTPUStep();
     applyUpdates();
   });
-  
+
   stepEdgeTPUCompile.addEventListener("click", function () {
     updateStepUI("EdgeTPUCompile");
   });
@@ -148,7 +150,7 @@ function registerCompileOptions() {
       edgeTPUDelegateSearchStep.value < 1
         ? "1"
         : edgeTPUDelegateSearchStep.value;
-        updateEdgeTPUCompile();
+    updateEdgeTPUCompile();
     applyUpdates();
   });
 }

--- a/media/EdgetpuCfgEditor/updateContent.js
+++ b/media/EdgetpuCfgEditor/updateContent.js
@@ -98,11 +98,6 @@ export function updateEdgeTPUCompile() {
     document.getElementById("EdgeTPUShowOperations").checked
   );
   content += iniKeyValueString(
-    "min_runtime_version",
-    document.getElementById("EdgeTPUMinRuntimeVersion").value,
-    "14"
-  );
-  content += iniKeyValueString(
     "search_delegate",
     document.getElementById("EdgeTPUSearchDelegate").checked
   );

--- a/media/EdgetpuCfgEditor/updateContent.js
+++ b/media/EdgetpuCfgEditor/updateContent.js
@@ -39,23 +39,23 @@ export function applyUpdates() {
   postMessageToVsCode({ type: "updateDocument" });
 }
 
-export function updateEdgeTPUStep(){
+export function updateEdgeTPUStep() {
   postMessageToVsCode({
     type: "setParam",
     section: "edgetpu-compiler",
     param: "edgetpu-compile",
     value: document.getElementById("checkboxEdgeTPUCompile").checked
-    ? "True"
-    : "False",
-  }); 
+      ? "True"
+      : "False",
+  });
   postMessageToVsCode({
     type: "setParam",
     section: "edgetpu-compiler",
     param: "edgetpu-profile",
     value: document.getElementById("checkboxEdgeTPUProfile").checked
-    ? "True"
-    : "False",
-  }); 
+      ? "True"
+      : "False",
+  });
 }
 
 function addPostfixToFileName(filePath = "", postfix = "") {

--- a/media/EdgetpuCfgEditor/updateUI.js
+++ b/media/EdgetpuCfgEditor/updateUI.js
@@ -53,7 +53,7 @@ export function updateEdgeTPUCompileUI() {
 
   edgeTPUBasicOptions.style.display = "none";
   edgeTPUAdvancedOptions.style.display = "none";
-  
+
   edgeTPUDelegateSearchStepDiv.style.display = edgeTPUSearchDelegate.checked
     ? "block"
     : "none";

--- a/media/EdgetpuCfgEditor/updateUI.js
+++ b/media/EdgetpuCfgEditor/updateUI.js
@@ -44,9 +44,6 @@ export function updateEdgeTPUCompileUI() {
   const edgeTPUAdvancedOptions = document.getElementById(
     "optionImportEdgeTPUAdvanced"
   );
-  const edgeTPUMinRuntimeVersion = document.getElementById(
-    "EdgeTPUMinRuntimeVersion"
-  );
   const edgeTPUSearchDelegate = document.getElementById(
     "EdgeTPUSearchDelegate"
   );
@@ -54,17 +51,9 @@ export function updateEdgeTPUCompileUI() {
     "EdgeTPUDelegateSearchStepDiv"
   );
 
-  const versionList = [10, 11, 12, 13, 14];
-
   edgeTPUBasicOptions.style.display = "none";
   edgeTPUAdvancedOptions.style.display = "none";
-
-  if (edgeTPUMinRuntimeVersion.childElementCount !== versionList.length) {
-    versionList.forEach((version) => {
-      var option = new Option(version);
-      edgeTPUMinRuntimeVersion.append(option);
-    });
-  }
+  
   edgeTPUDelegateSearchStepDiv.style.display = edgeTPUSearchDelegate.checked
     ? "block"
     : "none";


### PR DESCRIPTION
- All compiler versions are supported runtime version 14.
- So this option is meaningless anymore so removed it.

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>