### PR TITLE
[EdgeTPU] Resolve duplication of 'setDefaultValues'

### DIFF
--- a/media/EdgetpuCfgEditor/index.js
+++ b/media/EdgetpuCfgEditor/index.js
@@ -40,8 +40,8 @@ function main() {
       case "displayCfgToEditor":
         displayCfgToEditor(message.text);
         break;
-      case "setDefaultValues":
-        setDefaultValues(message.name);
+      case "setDefaultEdgetpuValues":
+        setDefaultEdgetpuValues(message.name);
         break;
       case "applyDialogPath":
         document.getElementById(message.elemID).value = message.path;
@@ -62,7 +62,12 @@ function main() {
   postMessageToVsCode({ type: "requestDisplayCfg" });
 }
 
-function setDefaultValues(name) {
+function setDefaultEdgetpuValues(name) {
+  // EdgeTPu COmpiler steps
+  document.getElementById("checkboxEdgeTPUCompile").checked = true;
+
+  updateEdgeTPUStep(); 
+
   // compile step
   let compiledName = name + ".tflite";
   let compiledExt = name + "_edgetpu.tflite";

--- a/package.json
+++ b/package.json
@@ -302,6 +302,11 @@
         "category": "ONE"
       },
       {
+        "command": "one.editor.cfg.setDefaultEdgetpuValues",
+        "title": "ONE: Set Default EdgeTPU Compiler Values",
+        "category": "ONE"
+      },
+      {
         "command": "one.editor.mpq.createFromDefaultExplorer",
         "title": "Create MPQ json",
         "category": "ONE"
@@ -317,6 +322,11 @@
         "command": "one.cfgEditor.setDefaultValues",
         "key": "ctrl+shift+/",
         "when": "activeCustomEditorId == one.editor.cfg"
+      },
+      {
+        "command": "one.cfgEditor.setDefaultEdgetpuValues",
+        "key": "ctrl+shift+/",
+        "when": "activeCustomEditorId == one.editor.edgetpucfg"
       },
       {
         "command": "one.explorer.deleteOnShortcut",

--- a/src/CfgEditor/EdgetpuCfgEditorPanel.ts
+++ b/src/CfgEditor/EdgetpuCfgEditorPanel.ts
@@ -72,7 +72,7 @@ export class EdgetpuCfgEditorPanel implements ICfgEditorPanel {
         }
       ),
       // Add command registration here
-      vscode.commands.registerCommand("one.cfgEditor.setDefaultValues", () => {
+      vscode.commands.registerCommand("one.cfgEditor.setDefaultEdgetpuValues", () => {
         if (!provider._activeWebviewPanel || !provider._activeDocument) {
           return;
         }
@@ -80,7 +80,7 @@ export class EdgetpuCfgEditorPanel implements ICfgEditorPanel {
         const cfgName = path.parse(provider._activeDocument!.fileName).name;
 
         provider._activeWebviewPanel!.webview.postMessage({
-          type: "setDefaultValues",
+          type: "setDefaultEdgetpuValues",
           name: cfgName,
         });
       }),


### PR DESCRIPTION
- Change 'setDefaultVaules' in files about EdgeTPU to 'setDefaultEdgetpuValues'
- Add objects about setDefaultEdgetpuValues in Commands and Keybindings in package.json
- Add "edgetpu-compile=True" in setDefaultEdgetpuValues in index.js

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>