### PR TITLE
[EdgeTPU] Bug Fix 'Input path' Dialog and 'Delegate Search Step' Display

### DIFF
--- a/media/EdgetpuCfgEditor/index.js
+++ b/media/EdgetpuCfgEditor/index.js
@@ -128,6 +128,7 @@ function registerCompileOptions() {
   edgeTPUIntermediateTensors.addEventListener("input", function () {
     if (edgeTPUSearchDelegate.checked) {
       edgeTPUSearchDelegate.checked = false;
+      edgeTPUDelegateSearchStepDiv.style.display = "none";
     }
     updateEdgeTPUCompile();
     applyUpdates();

--- a/media/EdgetpuCfgEditor/index.js
+++ b/media/EdgetpuCfgEditor/index.js
@@ -32,6 +32,7 @@ window.addEventListener("load", main);
 function main() {
   registerCompilerStep();
   registerCompileOptions();
+  registerCodiconEvents();
 
   // event from vscode extension
   window.addEventListener("message", (event) => {
@@ -153,4 +154,19 @@ function registerCompileOptions() {
     updateEdgeTPUCompile();
     applyUpdates();
   });
+}
+
+function registerCodiconEvents() {
+  document
+    .getElementById("EdgeTPUInputPathSearch")
+    .addEventListener("click", function () {
+      postMessageToVsCode({
+        type: "getPathByDialog",
+        isFolder: false,
+        ext: ["tflite"],
+        oldPath: document.getElementById("EdgeTPUInputPath").value,
+        postStep: "EdgeTPUCompile",
+        postElemID: "EdgeTPUInputPath",
+      });
+    });
 }


### PR DESCRIPTION
[EdgeTPU] Bug Fix Input_path Dialog

- When clicked input_path search codicon, nothing changed but now dialog is shown.

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>

------
[EdgeTPU] Bug Fix Delegate Search Display

- When intermediate tensors option got data, display of delegate search option changes to 'none'.

ONE-vscode-DCO-1.0-Signed-off-by: hohee-hee <khappy517@gmail.com>