### PR TITLE
[EdgeTPU] Update the ToolchainProvider.test.ts file

### DIFF
--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -34,21 +34,22 @@ import {
   MockCompilerWithMultipleInstalledToolchains,
   MockCompilerWithNoInstalledToolchain,
 } from "../MockCompiler";
+import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("Toolchain", function () {
+  const oneToolhcainEnv = new ToolchainEnv(new OneCompiler());
   const oneBackendName = "ONE";
   const compiler = new MockCompiler();
   const toolchainEnv = new ToolchainEnv(compiler);
   const backendName = "dummy_backend";
 
   setup(function () {
-    gToolchainEnvMap[backendName] = toolchainEnv;
-  });
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
 
-  teardown(function () {
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
+    gToolchainEnvMap[oneBackendName] = oneToolhcainEnv;
+    gToolchainEnvMap[backendName] = toolchainEnv;
   });
 
   suite("BaseNode", function () {


### PR DESCRIPTION
This commit updates the ToolchainProvider.test.ts file so that the testing codes work independent from addition of ToolchainEnv.

AS-IS:
Even though the purpose is not to test the registration of backend and toolchainEnv, the test codes should be updated whenever new backends and toolchainEnvs are registered.

TO-BE:
The test codes only use the toolchainEnv of ONE and dummy_backend regardless of backend and toolchainEnv registered in the extension.ts file.

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>