### PR TITLE
[EdgeTPU] Fix section name being read in the run() method

### DIFF
--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -26,45 +26,45 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
     let cmd = new Command("edgetpu_compiler");
     var config = ini.parse(fs.readFileSync(cfg, "utf-8").trim());
 
-    if (config["one-import-edgetpu"] === undefined) {
+    if (config["edgetpu-compile"] === undefined) {
       return cmd;
     }
 
-    let outDir = path.dirname(config["one-import-edgetpu"]["output_path"]);
+    let outDir = path.dirname(config["edgetpu-compile"]["output_path"]);
     cmd.push("--out_dir");
     cmd.push(outDir);
 
     let intermediateTensors =
-      config["one-import-edgetpu"]["intermediate_tensors"];
+      config["edgetpu-compile"]["intermediate_tensors"];
     if (intermediateTensors !== undefined) {
       cmd.push("--intermediate_tensors");
       cmd.push(intermediateTensors);
     }
 
-    let showOperations = config["one-import-edgetpu"]["show_operations"];
+    let showOperations = config["edgetpu-compile"]["show_operations"];
     if (showOperations === "True") {
       cmd.push("--show_operations");
     }
 
-    let minRuntimeVersion = config["one-import-edgetpu"]["min_runtime_version"];
+    let minRuntimeVersion = config["edgetpu-compile"]["min_runtime_version"];
     if (minRuntimeVersion !== undefined) {
       cmd.push("--min_runtime_version");
       cmd.push(minRuntimeVersion);
     }
 
-    let searchDelegate = config["one-import-edgetpu"]["search_delegate"];
+    let searchDelegate = config["edgetpu-compile"]["search_delegate"];
     if (searchDelegate === "True") {
       cmd.push("--search_delegate");
     }
 
     let delegateSearchStep =
-      config["one-import-edgetpu"]["delegate_search_step"];
+      config["edgetpu-compile"]["delegate_search_step"];
     if (delegateSearchStep !== undefined) {
       cmd.push("--delegate_search_step");
       cmd.push(delegateSearchStep);
     }
 
-    let inputPath = config["one-import-edgetpu"]["input_path"];
+    let inputPath = config["edgetpu-compile"]["input_path"];
     cmd.push(inputPath);
 
     return cmd;

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -22,22 +22,7 @@ import { Version } from "../../../Backend/Version";
 import { TestBuilder } from "../../TestBuilder";
 
 const content = `
-[onecc]
-one-import-tf=False
-one-import-tflite=False
-one-import-bcq=False
-one-import-onnx=False
-one-optimize=False
-one-quantize=True
-one-pack=False
-one-codegen=False
-
-[one-quantize]
-input_path=./inception_v3_tflite.circle
-output_path=./inception_v3_tflite.q8.circle
-input_model_dtype=uint8
-
-[one-import-edgetpu]
+[edgetpu-compile]
 input_path=/home/workspace/models/sample.tflite
 output_path=/home/workspace/models/sample_edge_tpu.tflite
 intermediate_tensors=tensorName1,tensorName2
@@ -48,7 +33,7 @@ delegate_search_step=4
 `;
 
 const relativeOutputPathcontent = `
-[one-import-edgetpu]
+[edgetpu-compile]
 input_path=./sample.tflite
 output_path=./sample_edge_tpu.tflite
 intermediate_tensors=tensorName1,tensorName2


### PR DESCRIPTION
This commit changes the section name being read in the run() method.

AS-IS:
config["one-import-edgetpu"]

TO-BE:
config["edgetpu-compile"]

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>