### PR TITLE
[EdgeTPU] Update the Install Quick Input test code

### DIFF
--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -26,6 +26,7 @@ import {
   InstallQuickInputStep,
 } from "../../View/InstallQuickInput";
 import { MockCompiler } from "../MockCompiler";
+import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("View", function () {
   suite("InnerButton", function () {
@@ -45,21 +46,30 @@ suite("View", function () {
   // Therefore, we focus on testing things not ui
   suite("InstallQuickInput", function () {
     const oneBackendName = "ONE";
+    const oneCompiler = new OneCompiler();
+    const oneToolchainEnv = new ToolchainEnv(oneCompiler);
+
+    const backendName = "testBackend";
     const compiler = new MockCompiler();
     const toolchainEnv = new ToolchainEnv(compiler);
+
     const toolchainType = toolchainEnv.getToolchainTypes()[0];
     const toolchain = toolchainEnv.listAvailable(toolchainType, 0, 1)[0];
     const version = new Version(1, 0, 0).str();
-    const backendName = "testBackend";
 
     setup(function () {
+      Object.keys(gToolchainEnvMap).forEach(
+        (key) => delete gToolchainEnvMap[key]
+      );
+
+      gToolchainEnvMap[oneBackendName] = oneToolchainEnv;
       gToolchainEnvMap[backendName] = toolchainEnv;
     });
 
     teardown(function () {
-      if (gToolchainEnvMap[backendName] !== undefined) {
-        delete gToolchainEnvMap[backendName];
-      }
+      Object.keys(gToolchainEnvMap).forEach(
+        (key) => delete gToolchainEnvMap[key]
+      );
     });
 
     suite("#constructor()", function () {


### PR DESCRIPTION
This commit updates the InstallQuickInput.test.ts file so that the testing codes work independent from addition of Backend and ToolchainEnv.

AS-IS:
Even though the purpose is not to test the registration of backend and toolchainEnv, the test codes should be updated whenever new backends and toolchainEnvs are registered.

TO-BE:
The test codes only use the Backend and toolchainEnv of ONE and mockup regardless of backend and toolchainEnv registered in the extension.ts file.

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>