### PR TITLE
[EdgeTPU] Add teardown in ToolchainProvider test code

### DIFF
--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -52,6 +52,12 @@ suite("Toolchain", function () {
     gToolchainEnvMap[backendName] = toolchainEnv;
   });
 
+  teardown(function () {
+    Object.keys(gToolchainEnvMap).forEach(
+      (key) => delete gToolchainEnvMap[key]
+    );
+  });
+
   suite("BaseNode", function () {
     suite("#constructor()", function () {
       test("is constructed with params using base_node", function () {


### PR DESCRIPTION
Add teardown code in ToolchainProvider.test.ts to clear gToolchainEvnMap after ToolchainProvider test

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>