### PR TITLE
[EdgeTPU] Fix EdgeTPU Compiler Version to use undefined patch

### DIFF
--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -126,13 +126,13 @@ class EdgeTPUCompiler implements Compiler {
     major = Number(major);
     minor = Number(minor);
     patch = Number(patch);
-    
+
     if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
       throw Error("Invalid version format.");
     }
 
     if (splitedVersion.length === 2 && !option) {
-      return new Version(major, minor);
+      return new Version(major, minor, undefined);
     }
 
     return new Version(major, minor, patch, option);
@@ -237,7 +237,7 @@ class EdgeTPUCompiler implements Compiler {
     const description = installedToolchain.slice(descriptionIdx).trim();
 
     const depends: Array<PackageInfo> = [
-      new PackageInfo("edgetpu_compiler", new Version(16, 0)),
+      new PackageInfo("edgetpu_compiler", new Version(16, 0, undefined)),
     ];
     const toolchainInfo = new ToolchainInfo(
       this.toolchainName,

--- a/src/Backend/Version.ts
+++ b/src/Backend/Version.ts
@@ -23,7 +23,7 @@ class Version {
   constructor(
     major: number,
     minor: number | undefined,
-    patch?: number | undefined,
+    patch: number | undefined,
     option: string = ""
   ) {
     this.major = major;

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -147,7 +147,7 @@ suite("EdgeTPUCompiler", function () {
     test("returns Version object from string version without patch and option", function () {
       const edgeTPUCompiler = new EdgeTPUCompiler();
       const version1 = edgeTPUCompiler.parseVersion("16.0");
-      const version2 = new Version(16, 0);
+      const version2 = new Version(16, 0, undefined);
       assert.deepEqual(version1, version2);
     });
     test("returns Version object from string version without option", function () {


### PR DESCRIPTION
Modify patch in Version to be non-optional parameter
Modify EdgeTPU Compiler Version to use undefined patch

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>