### PR TITLE
[EdgeTPU] Add EdgeTPU Backend

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -24,7 +24,7 @@ import { Logger } from "../Utils/Logger";
  * Interface of backend map
  * - Use Object class to use the only string key
  */
-interface BackendMap {
+export interface BackendMap {
   [key: string]: Backend;
 }
 

--- a/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
+++ b/src/Backend/EdgeTPU/EdgeTPUToolchain.ts
@@ -14,13 +14,21 @@
  * limitations under the License.
  */
 
-import { Command } from "../Command";
-import { DebianToolchain } from "../ToolchainImpl/DebianToolchain";
-
+import * as cp from "child_process";
+import * as vscode from "vscode";
 import * as ini from "ini";
 import * as fs from "fs";
 import * as path from "path";
+
 import { Logger } from "../../Utils/Logger";
+import { pipedSpawnSync } from "../../Utils/PipedSpawnSync";
+import { Backend } from "../Backend";
+import { Command } from "../Command";
+import { Compiler } from "../Compiler";
+import { Executor } from "../Executor";
+import { PackageInfo, ToolchainInfo, Toolchains } from "../Toolchain";
+import { DebianToolchain } from "../ToolchainImpl/DebianToolchain";
+import { Version } from "../Version";
 
 class EdgeTPUDebianToolchain extends DebianToolchain {
   run(cfg: string): Command {
@@ -77,4 +85,217 @@ class EdgeTPUDebianToolchain extends DebianToolchain {
   }
 }
 
-export { EdgeTPUDebianToolchain };
+class EdgeTPUCompiler implements Compiler {
+  private readonly toolchainTypes: string[];
+  private readonly toolchainName: string;
+
+  constructor() {
+    this.toolchainName = "edgetpu-compiler";
+    this.toolchainTypes = ["latest"];
+  }
+
+  getToolchainTypes(): string[] {
+    return this.toolchainTypes;
+  }
+
+  parseVersion(version: string): Version {
+    if (!version.trim()) {
+      throw Error("Invalid version format.");
+    }
+
+    let _version = version;
+    let option = "";
+
+    const optionIndex = version.search(/[~+-]/);
+    if (optionIndex !== -1) {
+      option = version.slice(optionIndex);
+      _version = version.slice(0, optionIndex);
+    }
+
+    const splitedVersion = _version.split(".");
+
+    if (splitedVersion.length > 3) {
+      throw Error("Invalid version format.");
+    }
+
+    let major: number | string;
+    let minor: number | string;
+    let patch: number | string;
+
+    [major = "0", minor = "0", patch = "0"] = _version.split(".");
+
+    const epochIndex = major.search(/:/);
+    if (epochIndex !== -1) {
+      major = major.slice(epochIndex + 1);
+    }
+
+    major = Number(major);
+    minor = Number(minor);
+    patch = Number(patch);
+
+    if (isNaN(major) || isNaN(minor) || isNaN(patch)) {
+      throw Error("Invalid version format.");
+    }
+
+    if (splitedVersion.length === 2 && !option) {
+      return new Version(major, minor, undefined);
+    }
+
+    return new Version(major, minor, patch, option);
+  }
+
+  getToolchains(
+    _toolchainType: string,
+    _start: number,
+    _count: number
+  ): Toolchains {
+    if (_toolchainType !== "latest") {
+      throw Error(`Invalid toolchain type : ${_toolchainType}`);
+    }
+
+    if (_start < 0) {
+      throw Error(`wrong start number: ${_start}`);
+    }
+    if (_count < 0) {
+      throw Error(`wrong count number: ${_count}`);
+    }
+    if (_count === 0) {
+      return [];
+    }
+
+    try {
+      cp.spawnSync(`apt-cache show ${this.toolchainName}`);
+    } catch (error) {
+      throw Error(`Getting ${this.toolchainName} package list is failed`);
+    }
+
+    let result;
+    try {
+      result = pipedSpawnSync(
+        "apt-cache",
+        ["madison", `${this.toolchainName}`],
+        { encoding: "utf8" },
+        "awk",
+        ['{printf $3" "}'],
+        { encoding: "utf8" }
+      );
+    } catch (error) {
+      throw Error(
+        `Getting ${this.toolchainName} package version list is failed`
+      );
+    }
+
+    if (result.status !== 0) {
+      return [];
+    }
+
+    const toolchainVersions: string = result.stdout.toString();
+    const versionList = toolchainVersions.trim().split(" ");
+
+    const availableToolchains = new Toolchains();
+    for (const version of versionList) {
+      const toolchainInfo = new ToolchainInfo(
+        this.toolchainName,
+        "Description: test",
+        this.parseVersion(version)
+      );
+
+      const toolchain = new EdgeTPUDebianToolchain(toolchainInfo);
+      availableToolchains.push(toolchain);
+    }
+
+    return availableToolchains;
+  }
+
+  getInstalledToolchains(_toolchainType: string): Toolchains {
+    if (_toolchainType !== "latest") {
+      throw Error(`Invalid toolchain type : ${_toolchainType}`);
+    }
+
+    let result;
+    try {
+      result = cp.spawnSync(
+        "dpkg-query",
+        [
+          "--show",
+          `--showformat='\${Version} \${Description}'`,
+          `${this.toolchainName}`,
+        ],
+        { encoding: "utf8" }
+      );
+    } catch (error) {
+      throw new Error(
+        `Getting installed ${this.toolchainName} package list is failed`
+      );
+    }
+
+    if (result.status !== 0) {
+      return [];
+    }
+
+    // NOTE
+    // The output format string of dpkg-query is '${Version} ${Description}'.
+    // To remove the first and last single quote character of output string, it slices from 1 to -1.
+    const installedToolchain: string = result.stdout.toString().slice(1, -1);
+
+    const descriptionIdx = installedToolchain.search(" ");
+    const versionStr = installedToolchain.slice(0, descriptionIdx).trim();
+    const description = installedToolchain.slice(descriptionIdx).trim();
+
+    const depends: Array<PackageInfo> = [
+      new PackageInfo("edgetpu_compiler", new Version(16, 0, undefined)),
+    ];
+    const toolchainInfo = new ToolchainInfo(
+      this.toolchainName,
+      description,
+      this.parseVersion(versionStr),
+      depends
+    );
+    const toolchain = new EdgeTPUDebianToolchain(toolchainInfo);
+    return [toolchain];
+  }
+
+  prerequisitesForGetToolchains(): Command {
+    const extensionId = "Samsung.one-vscode";
+    const ext = vscode.extensions.getExtension(
+      extensionId
+    ) as vscode.Extension<any>;
+    const scriptPath = vscode.Uri.joinPath(
+      ext!.extensionUri,
+      "script",
+      "prerequisitesForGetEdgeTPUToolchain.sh"
+    ).fsPath;
+
+    const cmd = new Command("/bin/sh", [`${scriptPath}`]);
+    cmd.setRoot();
+    return cmd;
+  }
+}
+
+class EdgeTPUToolchain implements Backend {
+  private readonly backendName: string;
+  private readonly toolchainCompiler: EdgeTPUCompiler | undefined;
+
+  constructor() {
+    this.backendName = "EdgeTPU";
+    this.toolchainCompiler = new EdgeTPUCompiler();
+  }
+
+  name(): string {
+    return this.backendName;
+  }
+
+  compiler(): Compiler | undefined {
+    return this.toolchainCompiler;
+  }
+
+  executor(): Executor | undefined {
+    return undefined;
+  }
+
+  executors(): Executor[] {
+    return [];
+  }
+}
+
+export { EdgeTPUDebianToolchain, EdgeTPUCompiler, EdgeTPUToolchain };

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -16,14 +16,16 @@
 
 import { assert } from "chai";
 
-import { API, globalBackendMap } from "../../Backend/API";
+import { API, BackendMap, globalBackendMap } from "../../Backend/API";
+import { gToolchainEnvMap } from "../../Toolchain/ToolchainEnv";
 import { Backend } from "../../Backend/Backend";
 import { Compiler, CompilerBase } from "../../Backend/Compiler";
 import { Executor, ExecutorBase } from "../../Backend/Executor";
 import { OneToolchain } from "../../Backend/One/OneToolchain";
-import { gToolchainEnvMap } from "../../Toolchain/ToolchainEnv";
+import { EdgeTPUToolchain } from "../../Backend/EdgeTPU/EdgeTPUToolchain";
 
 const oneBackendName = "ONE";
+const edgeTPUBackendName = "EdgeTPU";
 
 // TODO: Move it to Mockup
 const backendName = "Mockup";
@@ -47,45 +49,38 @@ class BackendMockup implements Backend {
   }
 }
 
+const expectedGlobalBackendMap: BackendMap = {};
+expectedGlobalBackendMap[oneBackendName] = new OneToolchain();
+expectedGlobalBackendMap[edgeTPUBackendName] = new EdgeTPUToolchain();
+
 suite("Backend", function () {
   suite("backendAPI", function () {
     test("registers a OneToolchain", function () {
-      let oneBackend = new OneToolchain();
-      assert.strictEqual(Object.entries(globalBackendMap).length, 1);
-
       const entries = Object.entries(globalBackendMap);
-      assert.strictEqual(entries.length, 1);
-      // this runs once
-      for (const [key, value] of entries) {
-        assert.strictEqual(key, oneBackendName);
-        assert.deepStrictEqual(value, oneBackend);
-      }
-    });
-    test("registers a backend", function () {
-      assert.strictEqual(Object.entries(globalBackendMap).length, 1);
+      assert.strictEqual(entries.length, 2);
 
+      assert.deepStrictEqual(globalBackendMap, expectedGlobalBackendMap);
+    });
+
+    test("registers a backend", function () {
       let backend = new BackendMockup();
       API.registerBackend(backend);
 
       const entries = Object.entries(globalBackendMap);
-      assert.strictEqual(entries.length, 2);
+      assert.strictEqual(entries.length, 3);
 
-      // this runs once
-      for (const [key, value] of entries) {
-        if (key !== oneBackendName) {
-          assert.strictEqual(key, backendName);
-          assert.deepStrictEqual(value, backend);
-        }
+      assert.deepStrictEqual(backend, globalBackendMap[backend.name()]);
+
+      if (gToolchainEnvMap[backend.name()] !== undefined) {
+        delete gToolchainEnvMap[backend.name()];
       }
-    });
-  });
 
-  teardown(function () {
-    if (globalBackendMap[backendName] !== undefined) {
-      delete globalBackendMap[backendName];
-    }
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
+      if (globalBackendMap[backend.name()] !== undefined) {
+        delete globalBackendMap[backend.name()];
+      }
+
+      assert.isUndefined(gToolchainEnvMap[backend.name()]);
+      assert.isUndefined(globalBackendMap[backend.name()]);
+    });
   });
 });

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -37,18 +37,13 @@ import {
 
 suite("Toolchain", function () {
   const oneBackendName = "ONE";
+  const edgeTPUBackendName = "EdgeTPU";
+  const backendName = "dummy_backend";
   const compiler = new MockCompiler();
   const toolchainEnv = new ToolchainEnv(compiler);
-  const backendName = "dummy_backend";
 
   setup(function () {
     gToolchainEnvMap[backendName] = toolchainEnv;
-  });
-
-  teardown(function () {
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
   });
 
   suite("BaseNode", function () {
@@ -115,20 +110,22 @@ suite("Toolchain", function () {
     suite("#createBackendNodes()", function () {
       test("creates BackendNode list", function () {
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
       });
     });
     suite("#createToolchainNodes()", function () {
       test("creates ToolchainNode list", function () {
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
 
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        let bnode2: BackendNode = bnodes[1];
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        let bnode2: BackendNode = bnodes[2];
         let tnodes2 = NodeBuilder.createToolchainNodes(bnode2);
         assert.strictEqual(tnodes2.length, 1);
         tnodes2.forEach((tnode) => {
@@ -139,10 +136,11 @@ suite("Toolchain", function () {
     suite("#createToolchainNodes()", function () {
       test("NEG: creates ToolchainNode list using invalid backend node", function () {
         const bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        const tnodes1 = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        const tnodes1 = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.strictEqual(tnodes1.length, 1);
         tnodes1.forEach((tnode) => {
           assert.strictEqual(tnode.backendName, backendName);
@@ -196,20 +194,22 @@ suite("Toolchain", function () {
       test("gets Children with undefined", function (done) {
         let provider = new ToolchainProvider();
         provider.getChildren(undefined).then((bnodes) => {
-          assert.strictEqual(bnodes.length, 2);
+          assert.strictEqual(bnodes.length, 3);
           assert.strictEqual(bnodes[0].label, oneBackendName);
-          assert.strictEqual(bnodes[1].label, backendName);
+          assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+          assert.strictEqual(bnodes[2].label, backendName);
           done();
         });
       });
       test("gets Children with BackendNode", function (done) {
         let provider = new ToolchainProvider();
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        let bnode: BackendNode = bnodes[1];
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        let bnode: BackendNode = bnodes[2];
         provider.getChildren(bnode).then((tnodes) => {
           assert.strictEqual(tnodes.length, 1);
           tnodes.forEach((tnode) => {
@@ -255,11 +255,12 @@ suite("Toolchain", function () {
       test("requests uninstall", function () {
         const provider = new ToolchainProvider();
         const bnodes = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        const tnodes = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        const tnodes = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.isAbove(tnodes.length, 0);
         provider.uninstall(tnodes[0]);
         assert.isTrue(true);
@@ -336,11 +337,12 @@ suite("Toolchain", function () {
       test("request setDefaultToolchain", function () {
         const provider = new ToolchainProvider();
         const bnodes = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        const tnodes = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend, EdgeTPU Toolchain backend.
+        const tnodes = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.isAbove(tnodes.length, 0);
         provider.setDefaultToolchain(tnodes[0]);
         assert.isTrue(
@@ -365,5 +367,11 @@ suite("Toolchain", function () {
         assert.isFalse(ret);
       });
     });
+  });
+
+  teardown(function () {
+    if (gToolchainEnvMap[backendName] !== undefined) {
+      delete gToolchainEnvMap[backendName];
+    }
   });
 });

--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -45,21 +45,16 @@ suite("View", function () {
   // Therefore, we focus on testing things not ui
   suite("InstallQuickInput", function () {
     const oneBackendName = "ONE";
+    const edgeTPUBackendName = "EdgeTPU";
+    const backendName = "testBackend";
     const compiler = new MockCompiler();
     const toolchainEnv = new ToolchainEnv(compiler);
     const toolchainType = toolchainEnv.getToolchainTypes()[0];
     const toolchain = toolchainEnv.listAvailable(toolchainType, 0, 1)[0];
     const version = new Version(1, 0, 0).str();
-    const backendName = "testBackend";
 
     setup(function () {
       gToolchainEnvMap[backendName] = toolchainEnv;
-    });
-
-    teardown(function () {
-      if (gToolchainEnvMap[backendName] !== undefined) {
-        delete gToolchainEnvMap[backendName];
-      }
     });
 
     suite("#constructor()", function () {
@@ -372,9 +367,10 @@ suite("View", function () {
       test("gets all toolchain env names from global toolchain env", function () {
         let quickInput = new InstallQuickInput();
         let envs = quickInput.getAllToolchainEnvNames();
-        assert.strictEqual(envs.length, 2);
+        assert.strictEqual(envs.length, 3);
         assert.strictEqual(envs[0], oneBackendName);
-        assert.strictEqual(envs[1], backendName);
+        assert.strictEqual(envs[1], edgeTPUBackendName);
+        assert.strictEqual(envs[2], backendName);
       });
     });
 
@@ -665,6 +661,12 @@ suite("View", function () {
           quickInput.getMultiSteps(invalidState);
         }).to.throw(`state is wrong: ` + String(invalidState.current));
       });
+    });
+
+    teardown(function () {
+      if (gToolchainEnvMap[backendName] !== undefined) {
+        delete gToolchainEnvMap[backendName];
+      }
     });
   });
 });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,7 @@ import { Logger } from "./Utils/Logger";
 import { VisqViewerProvider } from "./Visquv/VisqViewer";
 import { MPQEditorProvider } from "./MPQEditor/MPQEditor";
 import { MPQSelectionPanel } from "./MPQEditor/MPQCircleSelector";
+import { EdgeTPUToolchain } from "./Backend/EdgeTPU/EdgeTPUToolchain";
 
 /* istanbul ignore next */
 export function activate(context: vscode.ExtensionContext) {
@@ -84,6 +85,7 @@ export function activate(context: vscode.ExtensionContext) {
   MPQSelectionPanel.register(context);
 
   API.registerBackend(new OneToolchain());
+  API.registerBackend(new EdgeTPUToolchain());
 
   // returning backend registration function that will be called by backend extensions
   return API;


### PR DESCRIPTION
Implement the EdgeTPUCompiler for EdgeTPUToolchain
Implement the EdgeTPUToolchain
Register EdgeTPUToolchain backend in extension.ts

Modify the testing codes to test registration of EdgeTPUToolchain
Also, This commit exports BackendMap interface to use it in the testing codes

ONE-vscode-DCO-1.0-Signed-off-by: profornnan <profornnan@naver.com>