### PR TITLE
[EdgeTPU] Update the testing codes to register EdgeTPUToolchain

### DIFF
--- a/src/Backend/API.ts
+++ b/src/Backend/API.ts
@@ -24,7 +24,7 @@ import { Logger } from "../Utils/Logger";
  * Interface of backend map
  * - Use Object class to use the only string key
  */
-interface BackendMap {
+export interface BackendMap {
   [key: string]: Backend;
 }
 

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -16,14 +16,16 @@
 
 import { assert } from "chai";
 
-import { API, globalBackendMap } from "../../Backend/API";
+import { API, BackendMap, globalBackendMap } from "../../Backend/API";
+import { gToolchainEnvMap } from "../../Toolchain/ToolchainEnv";
 import { Backend } from "../../Backend/Backend";
 import { Compiler, CompilerBase } from "../../Backend/Compiler";
 import { Executor, ExecutorBase } from "../../Backend/Executor";
 import { OneToolchain } from "../../Backend/One/OneToolchain";
-import { gToolchainEnvMap } from "../../Toolchain/ToolchainEnv";
+import { EdgeTPUToolchain } from "../../Backend/EdgeTPU/EdgeTPUToolchain";
 
 const oneBackendName = "ONE";
+const edgeTPUBackendName = "EdgeTPU";
 
 // TODO: Move it to Mockup
 const backendName = "Mockup";
@@ -47,30 +49,17 @@ class BackendMockup implements Backend {
   }
 }
 
-suite("Backend", function () {
-  setup(function () {
-    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-    Object.keys(globalBackendMap).forEach(
-      (key) => delete globalBackendMap[key]
-    );
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
-  });
+const expectedGlobalBackendMap: BackendMap = {};
+expectedGlobalBackendMap[oneBackendName] = new OneToolchain();
+expectedGlobalBackendMap[edgeTPUBackendName] = new EdgeTPUToolchain();
 
+suite("Backend", function () {
   suite("backendAPI", function () {
     test("registers a OneToolchain", function () {
-      let oneBackend = new OneToolchain();
-      API.registerBackend(oneBackend);
-
       const entries = Object.entries(globalBackendMap);
-      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries.length, 2);
 
-      // this runs once
-      for (const [key, value] of entries) {
-        assert.strictEqual(key, oneBackendName);
-        assert.deepStrictEqual(value, oneBackend);
-      }
+      assert.deepStrictEqual(globalBackendMap, expectedGlobalBackendMap);
     });
 
     test("registers a backend", function () {
@@ -78,13 +67,15 @@ suite("Backend", function () {
       API.registerBackend(backend);
 
       const entries = Object.entries(globalBackendMap);
-      assert.strictEqual(entries.length, 1);
+      assert.strictEqual(entries.length, 3);
 
-      // this runs once
-      for (const [key, value] of entries) {
-        assert.strictEqual(key, backendName);
-        assert.deepStrictEqual(value, backend);
+      assert.deepStrictEqual(backend, globalBackendMap[backend.name()]);
+
+      if (gToolchainEnvMap[backend.name()] !== undefined) {
+        delete gToolchainEnvMap[backend.name()];
       }
+
+      assert.isUndefined(gToolchainEnvMap[backend.name()]);
     });
   });
 

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -75,7 +75,12 @@ suite("Backend", function () {
         delete gToolchainEnvMap[backend.name()];
       }
 
+      if (globalBackendMap[backend.name()] !== undefined) {
+        delete globalBackendMap[backend.name()];
+      }
+
       assert.isUndefined(gToolchainEnvMap[backend.name()]);
+      assert.isUndefined(globalBackendMap[backend.name()]);
     });
   });
 

--- a/src/Tests/Backend/Backend.test.ts
+++ b/src/Tests/Backend/Backend.test.ts
@@ -83,14 +83,4 @@ suite("Backend", function () {
       assert.isUndefined(globalBackendMap[backend.name()]);
     });
   });
-
-  teardown(function () {
-    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-    Object.keys(globalBackendMap).forEach(
-      (key) => delete globalBackendMap[key]
-    );
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
-  });
 });

--- a/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
+++ b/src/Tests/Backend/EdgeTPU/EdgeTPUToolchain.test.ts
@@ -56,10 +56,6 @@ suite("Backend", function () {
       testBuilder.setUp();
     });
 
-    teardown(() => {
-      testBuilder.tearDown();
-    });
-
     suite("#run", function () {
       test("returns Command with cfg", function () {
         testBuilder.writeFileSync("file.cfg", content);
@@ -118,6 +114,10 @@ suite("Backend", function () {
 
         assert.deepEqual(cmd, expectedStrs);
       });
+    });
+
+    teardown(() => {
+      testBuilder.tearDown();
     });
   });
 });

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -34,23 +34,22 @@ import {
   MockCompilerWithMultipleInstalledToolchains,
   MockCompilerWithNoInstalledToolchain,
 } from "../MockCompiler";
-import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("Toolchain", function () {
-  const oneToolhcainEnv = new ToolchainEnv(new OneCompiler());
   const oneBackendName = "ONE";
+  const edgeTPUBackendName = "EdgeTPU";
+  const backendName = "dummy_backend";
   const compiler = new MockCompiler();
   const toolchainEnv = new ToolchainEnv(compiler);
-  const backendName = "dummy_backend";
 
   setup(function () {
-    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
-
-    gToolchainEnvMap[oneBackendName] = oneToolhcainEnv;
     gToolchainEnvMap[backendName] = toolchainEnv;
+  });
+
+  teardown(function () {
+    if (gToolchainEnvMap[backendName] !== undefined) {
+      delete gToolchainEnvMap[backendName];
+    }
   });
 
   suite("BaseNode", function () {
@@ -117,20 +116,22 @@ suite("Toolchain", function () {
     suite("#createBackendNodes()", function () {
       test("creates BackendNode list", function () {
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName); 
       });
     });
     suite("#createToolchainNodes()", function () {
       test("creates ToolchainNode list", function () {
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
 
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        let bnode2: BackendNode = bnodes[1];
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        let bnode2: BackendNode = bnodes[2];
         let tnodes2 = NodeBuilder.createToolchainNodes(bnode2);
         assert.strictEqual(tnodes2.length, 1);
         tnodes2.forEach((tnode) => {
@@ -141,10 +142,11 @@ suite("Toolchain", function () {
     suite("#createToolchainNodes()", function () {
       test("NEG: creates ToolchainNode list using invalid backend node", function () {
         const bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        const tnodes1 = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        const tnodes1 = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.strictEqual(tnodes1.length, 1);
         tnodes1.forEach((tnode) => {
           assert.strictEqual(tnode.backendName, backendName);
@@ -198,20 +200,22 @@ suite("Toolchain", function () {
       test("gets Children with undefined", function (done) {
         let provider = new ToolchainProvider();
         provider.getChildren(undefined).then((bnodes) => {
-          assert.strictEqual(bnodes.length, 2);
+          assert.strictEqual(bnodes.length, 3);
           assert.strictEqual(bnodes[0].label, oneBackendName);
-          assert.strictEqual(bnodes[1].label, backendName);
+          assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+          assert.strictEqual(bnodes[2].label, backendName);
           done();
         });
       });
       test("gets Children with BackendNode", function (done) {
         let provider = new ToolchainProvider();
         let bnodes: BackendNode[] = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        let bnode: BackendNode = bnodes[1];
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        let bnode: BackendNode = bnodes[2];
         provider.getChildren(bnode).then((tnodes) => {
           assert.strictEqual(tnodes.length, 1);
           tnodes.forEach((tnode) => {
@@ -257,11 +261,12 @@ suite("Toolchain", function () {
       test("requests uninstall", function () {
         const provider = new ToolchainProvider();
         const bnodes = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        const tnodes = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend and EdgeTPU Toolchain backend.
+        const tnodes = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.isAbove(tnodes.length, 0);
         provider.uninstall(tnodes[0]);
         assert.isTrue(true);
@@ -338,11 +343,12 @@ suite("Toolchain", function () {
       test("request setDefaultToolchain", function () {
         const provider = new ToolchainProvider();
         const bnodes = NodeBuilder.createBackendNodes();
-        assert.strictEqual(bnodes.length, 2);
+        assert.strictEqual(bnodes.length, 3);
         assert.strictEqual(bnodes[0].label, oneBackendName);
-        assert.strictEqual(bnodes[1].label, backendName);
-        // Ignore bnodes[0] because it is ONE Toolchain backend.
-        const tnodes = NodeBuilder.createToolchainNodes(bnodes[1]);
+        assert.strictEqual(bnodes[1].label, edgeTPUBackendName);
+        assert.strictEqual(bnodes[2].label, backendName);
+        // Ignore bnodes[0], bnodes[1] because these are ONE Toolchain backend, EdgeTPU Toolchain backend.
+        const tnodes = NodeBuilder.createToolchainNodes(bnodes[2]);
         assert.isAbove(tnodes.length, 0);
         provider.setDefaultToolchain(tnodes[0]);
         assert.isTrue(

--- a/src/Tests/Toolchain/ToolchainProvider.test.ts
+++ b/src/Tests/Toolchain/ToolchainProvider.test.ts
@@ -46,12 +46,6 @@ suite("Toolchain", function () {
     gToolchainEnvMap[backendName] = toolchainEnv;
   });
 
-  teardown(function () {
-    if (gToolchainEnvMap[backendName] !== undefined) {
-      delete gToolchainEnvMap[backendName];
-    }
-  });
-
   suite("BaseNode", function () {
     suite("#constructor()", function () {
       test("is constructed with params using base_node", function () {
@@ -376,9 +370,8 @@ suite("Toolchain", function () {
   });
 
   teardown(function () {
-    // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-    Object.keys(gToolchainEnvMap).forEach(
-      (key) => delete gToolchainEnvMap[key]
-    );
+    if (gToolchainEnvMap[backendName] !== undefined) {
+      delete gToolchainEnvMap[backendName];
+    }
   });
 });

--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -26,7 +26,6 @@ import {
   InstallQuickInputStep,
 } from "../../View/InstallQuickInput";
 import { MockCompiler } from "../MockCompiler";
-import { OneCompiler } from "../../Backend/One/OneToolchain";
 
 suite("View", function () {
   suite("InnerButton", function () {
@@ -46,25 +45,22 @@ suite("View", function () {
   // Therefore, we focus on testing things not ui
   suite("InstallQuickInput", function () {
     const oneBackendName = "ONE";
-    const oneCompiler = new OneCompiler();
-    const oneToolchainEnv = new ToolchainEnv(oneCompiler);
-
+    const edgeTPUBackendName = "EdgeTPU";
     const backendName = "testBackend";
     const compiler = new MockCompiler();
     const toolchainEnv = new ToolchainEnv(compiler);
-
     const toolchainType = toolchainEnv.getToolchainTypes()[0];
     const toolchain = toolchainEnv.listAvailable(toolchainType, 0, 1)[0];
     const version = new Version(1, 0, 0).str();
-
+    
     setup(function () {
-      // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-      Object.keys(gToolchainEnvMap).forEach(
-        (key) => delete gToolchainEnvMap[key]
-      );
-
-      gToolchainEnvMap[oneBackendName] = oneToolchainEnv;
       gToolchainEnvMap[backendName] = toolchainEnv;
+    });
+
+    teardown(function () {
+      if (gToolchainEnvMap[backendName] !== undefined) {
+        delete gToolchainEnvMap[backendName];
+      }
     });
 
     suite("#constructor()", function () {
@@ -377,9 +373,10 @@ suite("View", function () {
       test("gets all toolchain env names from global toolchain env", function () {
         let quickInput = new InstallQuickInput();
         let envs = quickInput.getAllToolchainEnvNames();
-        assert.strictEqual(envs.length, 2);
+        assert.strictEqual(envs.length, 3);
         assert.strictEqual(envs[0], oneBackendName);
-        assert.strictEqual(envs[1], backendName);
+        assert.strictEqual(envs[1], edgeTPUBackendName);
+        assert.strictEqual(envs[2], backendName);
       });
     });
 

--- a/src/Tests/View/InstallQuickInput.test.ts
+++ b/src/Tests/View/InstallQuickInput.test.ts
@@ -57,12 +57,6 @@ suite("View", function () {
       gToolchainEnvMap[backendName] = toolchainEnv;
     });
 
-    teardown(function () {
-      if (gToolchainEnvMap[backendName] !== undefined) {
-        delete gToolchainEnvMap[backendName];
-      }
-    });
-
     suite("#constructor()", function () {
       test("is constructed", function () {
         let quickInput = new InstallQuickInput();
@@ -670,10 +664,9 @@ suite("View", function () {
     });
 
     teardown(function () {
-      // TODO: provide delete function for backend, which recursively deleting toolchain and executors
-      Object.keys(gToolchainEnvMap).forEach(
-        (key) => delete gToolchainEnvMap[key]
-      );
+      if (gToolchainEnvMap[backendName] !== undefined) {
+        delete gToolchainEnvMap[backendName];
+      }
     });
   });
 });


### PR DESCRIPTION
This PR modifies the testing codes to test registration of EdgeTPUToolchain.
Also, This commit exports BackendMap interface to use it in the testing codes.

From #73 

ONE-vscode-DCO-1.0-Signed-off-by: Bumsoo Ko <rhqjatn2398@naver.com>